### PR TITLE
Only transform hashes to Hash::AsObject objects, leave other structures alone

### DIFF
--- a/lib/WWW/Wunderground/API.pm
+++ b/lib/WWW/Wunderground/API.pm
@@ -118,7 +118,10 @@ sub api_call {
     $struc = $struc->{$action_key} if $action_key;
     $self->data->{$action} = $struc;
 
-    return new Hash::AsObject($struc);
+    return 
+      ref($struc) eq "HASH" ? 
+        new Hash::AsObject($struc) :
+        $struc;
 	} else {
 	  warn "Only basic weather conditions are supported using the deprecated keyless interface";
 	  warn "please visit http://www.wunderground.com/weather/api to obtain your own API key";


### PR DESCRIPTION
... since Hash::AsObject doesn't support them and throws warnings
during global destruction.

This can be verified by running "wu" with "perl -w" enabled:

```
    $ perl -w -S wu
    Enter city or zip / postal code (New York City, NY): 94114
    ...
(in cleanup) Not a HASH reference at /Users/mschilli/perl5/lib/perl5/Hash/AsObject.pm line 102.
```

(there's a few other warnings still unfixed with Cache/FileBackend.pm, I'll leave that for another day).
