### PR TITLE
Transforms URL object into a string before caching it

### DIFF
--- a/lib/WWW/Wunderground/API.pm
+++ b/lib/WWW/Wunderground/API.pm
@@ -96,9 +96,10 @@ sub api_call {
     $url->query_form(%params);
 
     my $result;
-    unless ($result = $self->cache->get($url)) {
-      $result = get($url);
-      $self->cache->set($url,$result);
+    my $url_string = $url->as_string();
+    unless ($result = $self->cache->get($url_string)) {
+      $result = get($url_string);
+      $self->cache->set($url_string,$result);
     }
 
     $self->raw($result);


### PR DESCRIPTION
This gets rid of the 

```
&Digest::SHA1::sha1_hex function called with reference argument at     /Users/mschilli/perl5/lib/perl5/Cache/FileBackend.pm line 202, <> line 1.
```

warnings by using strings, not URL objects for the file cache.
